### PR TITLE
remove scroll bar and fix overlapping text on small devices

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,13 +7,19 @@ header {
 	text-align: center;
 	background-color: moccasin;
 	height: 1000px;
+	max-height: 100vh;
 	position: relative;
 }
 
 .banner {
-	font-size: 4rem;
+	font-size: 2rem;
 	font-family: "Courier New", Courier, monospace;
 	font-weight: bold;
+}
+@media (min-width: 615px) {
+	.banner {
+		font-size: 4rem;
+	}
 }
 
 .face {


### PR DESCRIPTION
hey just thought i'd remove the scroll bar for you as seemed unnecessary. 

i added a max-height: 100vh; which is 100% of the viewport.
i left your height 1000px because vh units can be buggy on old versions of iOS so this will do as a fall back for now.

i also reduced the font size of the banner on smaller screens so it doesn't overlap.